### PR TITLE
Fixed nippleSwitch method toggling touchscreen (method referred to "touchscreen" instead of "nipple")

### DIFF
--- a/spin.py
+++ b/spin.py
@@ -439,7 +439,7 @@ class interface(QtGui.QWidget):
                 engageCommand(
                     "xinput {status} \"{deviceName}\"".format(
                         status = xinputStatus[status],
-                        deviceName = self.deviceNames["touchscreen"]
+                        deviceName = self.deviceNames["nipple"]
                     )
                 )
             else:


### PR DESCRIPTION
After a few minutes of use, I noticed that the touchscreen does not function until after the digitizing pen is used (when proximity detection is enabled) causing the script to intentionally toggle the touchscreen. After a bit of poking and debugging, I found the cause. In the nippleSwitch method, the toggled device was "touchscreen" instead of "nipple".