### PR TITLE
add names of devices for Lenovo Yoga 370

### DIFF
--- a/spin.py
+++ b/spin.py
@@ -683,11 +683,15 @@ def get_inputs():
     ).communicate()[0]
     devices_and_keyphrases = {
         "touchscreen": ["SYNAPTICS Synaptics Touch Digitizer V04",
-                        "ELAN Touchscreen"],
+                        "ELAN Touchscreen",
+                        "Wacom Co.,Ltd. Pen and multitouch sensor Finger touch"],
         "touchpad":    ["PS/2 Synaptics TouchPad",
-                        "SynPS/2 Synaptics TouchPad"],
-        "nipple":      ["TPPS/2 IBM TrackPoint"],
-        "stylus":      ["Wacom ISDv4 EC Pen stylus"]
+                        "SynPS/2 Synaptics TouchPad",
+                        "ETPS/2 Elantech Touchpad"],
+        "nipple":      ["TPPS/2 IBM TrackPoint",
+                        "ETPS/2 Elantech TrackPoint"],
+        "stylus":      ["Wacom ISDv4 EC Pen stylus",
+                        "Wacom Co.,Ltd. Pen and multitouch sensor Pen stylus"]
     }
     names_devices = {}
     for device, keyphrases in devices_and_keyphrases.iteritems():


### PR DESCRIPTION
Hi,

thanks for spin! I'm adding device names needed for Lenovo Yoga 370.
Note that the buttons that I mentally link to the touchpad actually belong to the nipple, so switching off the nipple will disable your trackpad buttons.

There is one more thing that needs to be changed: the stylus_proximity_control method needs to use the detected name of the device and not the hardcoded "Wacom ISDv4 EC Pen stylus".

Cheers, Ondrej.